### PR TITLE
Improve provision and key mgmt implementation

### DIFF
--- a/include/key_mgmt.h
+++ b/include/key_mgmt.h
@@ -135,4 +135,14 @@ psa_status_t km_enc_pubkey_der(const enum km_key_idx key_idx,
 			       unsigned char *public_key,
 			       size_t public_key_size,
 			       size_t *public_key_len);
+
+/**
+ * @brief Set the key status.
+ *
+ * @param key_idx  Key context index.
+ * @param sts      Set status on the key context.
+ *
+ */
+void km_set_key_status(enum km_key_idx idx,
+                       enum km_key_stat sts);
 #endif /* KEY_MGMT_H */

--- a/include/provision.h
+++ b/include/provision.h
@@ -33,9 +33,14 @@ extern "C" {
  */
 #define APP_PS_HUBPORT (APP_PS_BASE + 0x0003)
 
+/** COSE key certificate.  Returned from CA server.
+ */
+#define APP_PS_COSE_CERT (APP_PS_BASE + 0x0004)
+
 /** Enum describing which fields are populated.
  */
 enum provision_present {
+        PROVISION_NOT_DONE = 0,
 	PROVISION_TLS_CERT = 1 << 0,
 	PROVISION_HUBNAME = 1 << 1,
 	PROVISION_HUBPORT = 1 << 2,

--- a/include/tfm_partition_huk.h
+++ b/include/tfm_partition_huk.h
@@ -31,13 +31,15 @@ psa_status_t psa_huk_get_pubkey(psa_key_id_t *key_id,
 /**
  * \brief Get the EC key status from HUK EC key status secure service
  *
- * \param[in] key_id    EC key id for persistent key
- * \param[in] stat      Pointer to the buffer to store the key status
+ * \param[in] key_id     EC key id for persistent key
+ * \param[in] stat       Pointer to the buffer to store the key status
+ * \param[in] set_status Boolean value to select a set/get the key status.
  *
  * \return Returns error code as specified in \ref psa_status_t
  */
 psa_status_t psa_huk_ec_key_stat(psa_key_id_t *key_id,
-				 enum km_key_stat *stat);
+				 enum km_key_stat *stat,
+				 _Bool set_status);
 
 /**
  * \brief Get the UUID from HUK generate UUID service

--- a/src/bootstrap.c
+++ b/src/bootstrap.c
@@ -182,14 +182,14 @@ static int decode_csr_response(struct provision_data *prov, const uint8_t *buf, 
 		if (res < 0) {
 			return res;
 		}
-		prov->present |= PROVISION_TLS_CERT;
+		prov->present = PROVISION_TLS_CERT;
 		break;
 	case KEY_COSE:
 		res = nanocbor_get_bstr(&map, &prov->cose_cert_der, &prov->cose_cert_der_len);
 		if (res < 0) {
 			return res;
 		}
-		prov->present |= PROVISION_COSE_CERT;
+		prov->present = PROVISION_COSE_CERT;
 		break;
 	case KEY_COUNT:
 		break;

--- a/src/key_mgmt.c
+++ b/src/key_mgmt.c
@@ -55,7 +55,7 @@ void km_context_init(struct km_key_context *ctx,
 	case KEY_ID_COSE:
 		/* Get the key status from the secure service. */
 		status = al_psa_status(
-			psa_huk_ec_key_stat(&ctx->key_id, &stat),
+			psa_huk_ec_key_stat(&ctx->key_id, &stat, false),
 			__func__);
 		if (status != PSA_SUCCESS) {
 			LOG_ERR("Failed to get the key status with %d\n", status);

--- a/src/provision.c
+++ b/src/provision.c
@@ -38,6 +38,7 @@ int provision_store(const struct provision_data *prov)
 		}
 
 		prov_present |= PROVISION_TLS_CERT;
+		km_set_key_status(KEY_CLIENT_TLS, KEY_X_509_CERT_GEN);
 	}
 
 	if ((prov->present & PROVISION_COSE_CERT) != 0) {
@@ -50,6 +51,7 @@ int provision_store(const struct provision_data *prov)
 		}
 
 		prov_present |= PROVISION_COSE_CERT;
+		km_set_key_status(KEY_COSE, KEY_X_509_CERT_GEN);
 	}
 
 	if ((prov->present & PROVISION_HUBNAME) != 0) {

--- a/src/shell/cmd_keys.c
+++ b/src/shell/cmd_keys.c
@@ -23,7 +23,7 @@ static int
 cmd_keys_key_stat(const struct shell *shell, size_t argc, char **argv)
 {
 	char *row1[] = { "Key", "Key ID", "Status" };
-	char *k_sts[] = { "unknown", "Key generated", "X.509 certificate gen" };
+	char *k_sts[] = { "unknown", "Key generated", "X.509 cert gen" };
 
 	shell_print(shell, "| %-24s| %-8s | %-14s |", row1[0], row1[1],
 		    row1[2]);

--- a/src/shell/cmd_keys.c
+++ b/src/shell/cmd_keys.c
@@ -19,21 +19,19 @@ LOG_MODULE_DECLARE(app, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if CONFIG_SECURE_INFER_SHELL_CMD_SUPPORT
 
-static int
-cmd_keys_key_stat(const struct shell *shell, size_t argc, char **argv)
+static int cmd_keys_key_stat(const struct shell *shell, size_t argc, char **argv)
 {
-	char *row1[] = { "Key", "Key ID", "Status" };
-	char *k_sts[] = { "unknown", "Key generated", "X.509 cert gen" };
+	char *row1[] = {"Key", "Key ID", "Status"};
+	char *k_sts[] = {"unknown", "Key generated", "X.509 cert gen"};
 
-	shell_print(shell, "| %-24s| %-8s | %-14s |", row1[0], row1[1],
-		    row1[2]);
+	shell_print(shell, "| %-24s| %-8s | %-14s |", row1[0], row1[1], row1[2]);
 	for (int i = 0; i < KEY_COUNT; i++) {
 		struct km_key_context *ctx = km_get_context(i);
 		if (ctx == NULL) {
 			return -EINVAL;
 		}
-		shell_print(shell, "| %-24s| 0x%-6x | %-14s |", ctx->label,
-			    ctx->key_id, k_sts[ctx->status]);
+		shell_print(shell, "| %-24s| 0x%-6x | %-14s |", ctx->label, ctx->key_id,
+			    k_sts[ctx->status]);
 	}
 
 	return 0;
@@ -56,10 +54,9 @@ static _Bool cmd_keys_get_key_idx(uint32_t key_id, uint8_t *key_idx)
 	return false;
 }
 
-static int
-cmd_keys_pubkey(const struct shell *shell, size_t argc, char **argv)
+static int cmd_keys_pubkey(const struct shell *shell, size_t argc, char **argv)
 {
-	unsigned char public_key[512] = { 0 };
+	unsigned char public_key[512] = {0};
 	size_t public_key_len = 0;
 	uint8_t key_idx_start = 0, key_idx_end = KEY_COUNT;
 	psa_status_t status;
@@ -67,11 +64,9 @@ cmd_keys_pubkey(const struct shell *shell, size_t argc, char **argv)
 	if ((argc == 2) && (strcmp(argv[1], "help") == 0)) {
 		shell_print(shell, "Display public key(s) in PEM format\n");
 		shell_print(shell, "  $ %s %s <Key ID>\n", argv[-1], argv[0]);
-		shell_print(shell,
-			    "  [Key ID]   Optional: Key ID ('status' for list)\n");
+		shell_print(shell, "  [Key ID]   Optional: Key ID ('status' for list)\n");
 		shell_print(shell, "Example: $ %s %s", argv[-1], argv[0]);
-		shell_print(shell,
-			    "         $ %s %s 5001 (List public key of 5001 key ID)",
+		shell_print(shell, "         $ %s %s 5001 (List public key of 5001 key ID)",
 			    argv[-1], argv[0]);
 		return 0;
 	}
@@ -92,15 +87,11 @@ cmd_keys_pubkey(const struct shell *shell, size_t argc, char **argv)
 
 	while (key_idx_start < key_idx_end) {
 		public_key_len = 0;
-		status = km_enc_pubkey_pem(key_idx_start,
-					   public_key,
-					   sizeof(public_key),
+		status = km_enc_pubkey_pem(key_idx_start, public_key, sizeof(public_key),
 					   &public_key_len);
 
 		if (status != 0) {
-			return shell_com_rc_code(shell,
-						 "Failed to get the public key",
-						 status);
+			return shell_com_rc_code(shell, "Failed to get the public key", status);
 		}
 
 		struct km_key_context *ctx = km_get_context(key_idx_start);
@@ -117,13 +108,11 @@ cmd_keys_pubkey(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-static int
-cmd_keys_csr(const struct shell *shell, size_t argc, char **argv)
+static int cmd_keys_csr(const struct shell *shell, size_t argc, char **argv)
 {
 	uint8_t key_idx = 0;
 	x509_csr_fmt_t csr_fmt = CSR_NONE;
-	_Bool is_valid_csr_format = false,
-	      is_print_help = false;
+	_Bool is_valid_csr_format = false, is_print_help = false;
 	psa_status_t status;
 
 	if ((argc == 2) && (strcmp(argv[1], "help") == 0)) {
@@ -134,8 +123,7 @@ cmd_keys_csr(const struct shell *shell, size_t argc, char **argv)
 			shell_print(shell, "Error: missing argument(s)");
 		}
 		shell_print(shell, "Generate a CSR for the given key id and format\n");
-		shell_print(shell, "  $ %s %s <Format> <Key ID>\n",
-			    argv[-1], argv[0]);
+		shell_print(shell, "  $ %s %s <Format> <Key ID>\n", argv[-1], argv[0]);
 		shell_print(shell, "  <Format>   'PEM', 'JSON'");
 		shell_print(shell, "  <Key ID>   Run 'status' for key ID list\n");
 		shell_print(shell, "Example: $ %s %s PEM 5001", argv[-1], argv[0]);
@@ -173,37 +161,24 @@ cmd_keys_csr(const struct shell *shell, size_t argc, char **argv)
 	/* Get the UUID */
 	status = al_psa_status(km_get_uuid(uuid, sizeof(uuid)), __func__);
 	if (status != PSA_SUCCESS) {
-		return shell_com_rc_code(shell,
-					 "Unable to read UUID",
-					 status);
+		return shell_com_rc_code(shell, "Unable to read UUID", status);
 	}
 
 	/* Generate CSR using Mbed TLS */
-	status = x509_csr_generate(key_idx,
-				   csr,
-				   sizeof(csr),
-				   uuid,
-				   sizeof(uuid),
-				   csr_fmt);
+	status = x509_csr_generate(key_idx, csr, sizeof(csr), uuid, sizeof(uuid), csr_fmt);
 	if (status < 0) {
-		return shell_com_rc_code(shell,
-					 "Failed to generate CSR",
-					 status);
+		return shell_com_rc_code(shell, "Failed to generate CSR", status);
 	}
 	if (csr_fmt == CSR_PEM_FORMAT) {
 		shell_print(shell, "%s", csr);
 	}
 	if (csr_fmt == CSR_JSON_FORMAT) {
-		static unsigned char csr_json[1024] = { 0 };
+		static unsigned char csr_json[1024] = {0};
 
 		/* CSR encode to JSON format */
-		status = x509_csr_json_encode(csr,
-					      csr_json,
-					      sizeof(csr_json));
+		status = x509_csr_json_encode(csr, csr_json, sizeof(csr_json));
 		if (status != 0) {
-			return shell_com_rc_code(shell,
-						 "Failed to encode CSR",
-						 status);
+			return shell_com_rc_code(shell, "Failed to encode CSR", status);
 		}
 		shell_print(shell, "%s", csr_json);
 	}
@@ -212,8 +187,7 @@ cmd_keys_csr(const struct shell *shell, size_t argc, char **argv)
 }
 
 #ifdef CONFIG_APP_NETWORKING
-static int
-cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
+static int cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 {
 	shell_print(shell, "argc: %d", argc);
 	if (argc < 2 || strcmp(argv[1], "help") == 0) {
@@ -251,9 +225,7 @@ cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 
 	int status = bootstrap_open(&bctx);
 	if (status != 0) {
-		return shell_com_rc_code(shell,
-					 "Failed to talk to bootstrap server",
-					 status);
+		return shell_com_rc_code(shell, "Failed to talk to bootstrap server", status);
 	}
 
 	/* Request is static to prevent stack overflow. */
@@ -261,9 +233,7 @@ cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 	status = bootstrap_csr(&bctx, &req, key_idx);
 	if (status != 0) {
 		// TODO: Need to close on error.
-		return shell_com_rc_code(shell,
-					 "Unable to process CSR",
-					 status);
+		return shell_com_rc_code(shell, "Unable to process CSR", status);
 	}
 
 	/* If this is the TLS message, also retrieve the service
@@ -272,8 +242,7 @@ cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 		status = bootstrap_service(&bctx);
 		if (status != 0) {
 			// TODO: Need to close on error.
-			return shell_com_rc_code(shell,
-						 "Unable to request service information",
+			return shell_com_rc_code(shell, "Unable to request service information",
 						 status);
 		}
 	}
@@ -286,9 +255,7 @@ cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	if (status != 0) {
-		return shell_com_rc_code(shell,
-					 "Failed to talk to bootstrap server",
-					 status);
+		return shell_com_rc_code(shell, "Failed to talk to bootstrap server", status);
 	}
 
 	return 0;
@@ -297,19 +264,20 @@ cmd_keys_ca(const struct shell *shell, size_t argc, char **argv)
 
 /* Subcommand array for "keys" (level 1). */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_cmd_keys,
-	/* 'Status' command handler. */
-	SHELL_CMD(status, NULL, "Device keys status", cmd_keys_key_stat),
-	/* 'Public key' command handler. */
-	SHELL_CMD(public, NULL, "List public key(s) and key IDs", cmd_keys_pubkey),
-	/* 'CSR' command handler. */
-	SHELL_CMD(csr, NULL, "Generate and display CSR on given key ID", cmd_keys_csr),
+			       /* 'Status' command handler. */
+			       SHELL_CMD(status, NULL, "Device keys status", cmd_keys_key_stat),
+			       /* 'Public key' command handler. */
+			       SHELL_CMD(public, NULL, "List public key(s) and key IDs",
+					 cmd_keys_pubkey),
+			       /* 'CSR' command handler. */
+			       SHELL_CMD(csr, NULL, "Generate and display CSR on given key ID",
+					 cmd_keys_csr),
 #ifdef CONFIG_APP_NETWORKING
-	/* 'CA' command handler. */
-	SHELL_CMD(ca, NULL, "Request certificate from CA", cmd_keys_ca),
+			       /* 'CA' command handler. */
+			       SHELL_CMD(ca, NULL, "Request certificate from CA", cmd_keys_ca),
 #endif
-	/* Array terminator. */
-	SHELL_SUBCMD_SET_END
-	);
+			       /* Array terminator. */
+			       SHELL_SUBCMD_SET_END);
 
 /* Root command "keys" (level 0). */
 SHELL_CMD_REGISTER(keys, &sub_cmd_keys, "Key Management", NULL);


### PR DESCRIPTION
- Add key set status API to set the key context status.
- Extend the provision store implementation to support COSE certificate storage to PS.
- csr callback request decodes the csr function and updates the provision data structure accordingly, it's defined as the local context variable, so update the provision data structure prov_present flag accordingly.
- Extend the provision store function and also updtate the key status context along with storing the received certificate to PS.
- The secure and Non-secure sides maintain the status of the key context, and these changes are to extend the existing huk key ec stat service can set the key status from the non-secure side for setting X509 key cert status once the certificate is generated on non-secure side.
- Strip down the x509 certificate gen to the short form to print key status command print in aligned table format.
-