### PR TITLE
flow: Add script to create simple keys

### DIFF
--- a/tools/flow/README.md
+++ b/tools/flow/README.md
@@ -4,6 +4,30 @@ Flow doesn't try to recreate the key creation parts of what
 `lite_bootstrap_server` does, so we will start by using the scripts from that
 tool to create the service key as well as the device keys.
 
+There are two ways to setup the keys for flow. You can use the
+`lite_bootstrap_server` to create the keys and certificates, or you can use a
+small script with the tool that creates simple self-signed certificates that are
+sufficient for flow.
+
+## Simple self-signed certs
+
+The `./create-certs.sh` script will create device and cloud1 certificates that
+will allow the commands below to demonstrate the flow. These certificates will
+be self signed, and not verified or correlated to any other keys. This makes it
+easy to quickly test with flow.
+
+```
+$ ./create-certs.sh
+```
+
+## Using the `lite_bootstrap_server`
+
+If you already have the `lite_bootstrap_server` running, it maybe easiest to
+just use keys that it has created. At the time of writing, this tool was only
+able to create device certificates. However, since flow doesn't really care
+about the details of the certificate, the cloud service can be faked by just
+creating another device key for it.
+
 The `setup-ca.sh` can be used to create the CA.cert file.  We will
 need to create key for the service, which can be created as if it were
 an ordinary device:

--- a/tools/flow/create-certs.sh
+++ b/tools/flow/create-certs.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+set -e
+
+# Create the minimal certificates required for the flow demo.
+#
+# Flow does not care about the contents of the certificates, only about the
+# subject name, and the keys used. This script will create a pair of minimal
+# certificates that are just self signed. It is also possible to use the
+# `lite_bootstrap_server` to create certificates, according to the instructions
+# in the `README.md`.
+
+# Make a key with a basename of $1 and a subject of $2
+make_key()
+{
+    if [[ -f "$1".pk8 ]] || [[ -f "$1".key ]] || [[ -f "$1".crt ]]; then
+        echo "Files exist with base of $1.*"
+        exit 1
+    fi
+
+    # Create the private key
+    openssl ecparam -name prime256v1 -genkey -out "$1".key
+
+    # Convert to pkcs 8
+    openssl pkcs8 -in "$1".key -inform PEM \
+            -out "$1".pk8 \
+            -topk8 -nocrypt
+
+    # Generate a signed certificate.
+    openssl req -new -x509 -days 3650 -key "$1".key \
+            -out "$1".crt \
+            -subj "$2"
+}
+
+mkdir -p certs
+make_key certs/cloud1 "/O=Linaro/CN=Flow test cloud"
+make_key certs/device "/O=Linaro/CN=Flow test device"


### PR DESCRIPTION
Instead of requiring the user to use the `lite_bootstrap_server`, provide a simple script that will create the necessary self-signed certificates for use by the flow tool.