### PR TITLE
Update Confidential AI work with latest zephyr v3.4.0 rc1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ assumptions in this codebase are met.
 
 This Zephyr commit hash used is:
 
-- ``9a759025d9123c7871308173a5fa31657a43a179``
+- ``183e0f854b83de58e7565b297d2af95e52e6a54c``
 
 Run these commands to checkout the expected commit hash, and apply a required
 patch to TF-M, allowing us to enable CPP support in the TF-M build system. This
@@ -173,7 +173,7 @@ allocation for the secure image(s), where required:
 
    $ cd path/to/zephyrproject/zephyr
    $ source zephyr-env.sh
-   $ git checkout 9a759025d9123c7871308173a5fa31657a43a179
+   $ git checkout 183e0f854b83de58e7565b297d2af95e52e6a54c
    $ west update
    $ cd ../modules/tee/tf-m/trusted-firmware-m
    $ git apply --verbose <zephyr_secure_inference_path>/patch/tfm.patch

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Linaro Limited
+ * Copyright (c) 2021-2023 Linaro Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,7 +16,7 @@
 /** Declare a reference to the application logging interface. */
 LOG_MODULE_DECLARE(app, CONFIG_LOG_DEFAULT_LEVEL);
 
-void main(void)
+int main(void)
 {
 	psa_status_t status;
 	unsigned char uuid[37];
@@ -40,6 +40,7 @@ void main(void)
 	status = al_psa_status(km_get_uuid(uuid, sizeof(uuid)), __func__);
 	if (status != PSA_SUCCESS) {
 		LOG_ERR("Unable to read UUID.");
-		return;
 	}
+
+	return status;
 }


### PR DESCRIPTION
- The latest version of Zephyr releases the expected main() function, which is supposed to return an int rather than a void to capture the application status.
- Update the docs to the Zephyr setup section steps to refer to the Zephyr v3.4.0-rc1 SHA.